### PR TITLE
middlewares, redux-persist

### DIFF
--- a/AlexanderMandrov/React/Messenger/package-lock.json
+++ b/AlexanderMandrov/React/Messenger/package-lock.json
@@ -2724,6 +2724,14 @@
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
       "dev": true
     },
+    "connected-react-router": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.8.0.tgz",
+      "integrity": "sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -3081,6 +3089,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -9962,6 +9975,19 @@
       "version": "2.13.8",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
       "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
+      }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
     },
     "redux-thunk": {
       "version": "2.3.0",

--- a/AlexanderMandrov/React/Messenger/package.json
+++ b/AlexanderMandrov/React/Messenger/package.json
@@ -33,6 +33,8 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "classnames": "^2.2.6",
+    "connected-react-router": "^6.8.0",
+    "history": "^4.10.1",
     "immutability-helper": "^3.1.1",
     "nanoid": "^3.1.12",
     "npm": "^6.14.8",
@@ -43,6 +45,8 @@
     "react-spinners": "^0.9.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
+    "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0"
   }
 }

--- a/AlexanderMandrov/React/Messenger/src/components/Chat/Message/Message.jsx
+++ b/AlexanderMandrov/React/Messenger/src/components/Chat/Message/Message.jsx
@@ -36,7 +36,8 @@ const Message = ({ message, deleteMessage, isBot, user }) => {
   const { text, username, id, date } = message;
 
   const alignStyles = isBot ? 'left' : 'right';
-  const time = isBot ? new Date(date.getTime() + 1000) : date;
+  const dateFromStr = new Date(date);
+  const time = isBot ? new Date(dateFromStr.getTime() + 2000) : new Date(dateFromStr);
 
   const btn = (
     <Box pt={1}>

--- a/AlexanderMandrov/React/Messenger/src/components/Header/Header.jsx
+++ b/AlexanderMandrov/React/Messenger/src/components/Header/Header.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 import './Header.scss';
 import Spinner from '../Spinner';
 import { makeStyles } from '@material-ui/core/styles';
@@ -44,7 +45,7 @@ const Header = () => {
       <AppBar position="static" className={appBar}>
         <Toolbar>
           <Typography variant="h6" className={title}>
-            <Link to="/" className="Header-link__reset">Messenger</Link>
+            <div onClick={() => dispatch(push('/'))}>Messenger</div>
           </Typography>
           <Typography variant="h6" className={title}>
               {data === null ?  <Spinner size={40} color="white" /> : `${data.username} ${sticker === null ? '' : sticker}`}

--- a/AlexanderMandrov/React/Messenger/src/components/Sidebar/Sidebar.jsx
+++ b/AlexanderMandrov/React/Messenger/src/components/Sidebar/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 import { nanoid } from 'nanoid';
 import './Sidebar.scss';
 import Spinner from '../Spinner';
@@ -9,15 +10,11 @@ import { Drawer, List, ListItem, ListItemText,
         makeStyles, Box, IconButton, TextField } from '@material-ui/core';
 import { deepOrange, deepPurple, green, blue, indigo, teal, cyan, lime } from '@material-ui/core/colors';
 import { AddCircleOutline } from '@material-ui/icons';
-import { fetchChats, setNewChat, setSendBotMessage } from '../../redux/ducks/chats';
-import { usernames, notifications, avatarColors, createPrimaryChats } from '../../constants/constants';
-import { messageShorter, validateInput, setDelay } from '../../utils/utils';
+import { fetchChats, setNewChat, setReceiver } from '../../redux/ducks/chats';
+import { usernames, createPrimaryChats } from '../../constants/constants';
+import { messageShorter, validateInput } from '../../utils/utils';
 
 const useStyles = makeStyles((theme) => ({
-  badge: {
-    top: 8,
-    marginBottom: 8
-  },
   green: {
     backgroundColor: green[500],
   },
@@ -46,32 +43,27 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Sidebar = ({ user, onChatClick }) => {
+const Sidebar = ({ user, onChatClick, activeChat }) => {
   const dispatch = useDispatch();
   const { chatsReducer } = useSelector((state) => state);
   const { chats } = chatsReducer;
 
   const classes = useStyles();
-  const { badge, green, orange, purple, blue, indigo, teal, cyan, lime } = classes;
+  const { green, orange, purple, blue, indigo, teal, cyan, lime } = classes;
 
   const [newReceiver, setNewReceiver] = useState('');
   const palette = [purple, orange, green, blue, indigo, teal, cyan, lime];
 
   useEffect(() => {
-    if (!chats) {
-      dispatch(fetchChats(usernames));
-    }
+    if (!chats) dispatch(fetchChats(usernames));
   }, []);
-
-  const handleChange = (event) => {
-    setNewReceiver(event.target.value)
-  };
 
   const handleClick = () => {
     if (validateInput(newReceiver)) {
       const chat = createPrimaryChats([newReceiver], user)[0];
       dispatch(setNewChat(chat));
-      setDelay(user, newReceiver, dispatch, setSendBotMessage);
+      dispatch(push(`/chats/${newReceiver}`));
+      dispatch(setReceiver(newReceiver));
       setNewReceiver('');
     }
   };
@@ -85,7 +77,7 @@ const Sidebar = ({ user, onChatClick }) => {
           placeholder="Create new chat"
           value={newReceiver}
           fullWidth
-          onChange={handleChange}
+          onChange={(event) => setNewReceiver(event.target.value)}
         />
         <Box ml={1} mb={0} mt={-0.5}>
           <IconButton
@@ -98,21 +90,36 @@ const Sidebar = ({ user, onChatClick }) => {
         </Box>
       </Box>
       <Divider />
-      <List className="Sidebar-list">
-        {chats === null ? <Spinner color="teal"/> : chats.map(({ username, id, messages }, idx) => {
-          const lastMessage = messages[messages.length - 1];
-          const lastMessageText = messageShorter(lastMessage.text);
+      <List className="Sidebar-list" disablePadding>
+        {chats === null ? <Spinner color="teal"/> : chats.map(({ username, messages, fired }, idx) => {
+          const lastMessage = messages.length ? messages[messages.length - 1] : '';
+          const lastMessageText =  messages.length ? 
+            messageShorter(messages[messages.length - 1].text) : 
+            'No messages here yet';
           return (
-            <Link to={`/chats/${username}`} className="Sidebar-link__reset" key={nanoid()} onClick={onChatClick.bind(this, username)}>
-              <ListItem button divider>
-                  <ListItemAvatar>
-                    <Badge color="secondary" badgeContent={notifications[idx]} className={badge}>
-                      <Avatar className={palette[avatarColors[idx]]}>
-                        {username.slice(0, 1).toUpperCase()}
-                      </Avatar>
-                    </Badge>
-                  </ListItemAvatar>
-                  <ListItemText classes={{ secondary: 'Sidebar-last__message' }} primary={username} secondary={lastMessage.username === user ? `You: ${lastMessageText}` : `${lastMessageText}`}/>
+            <Link 
+              to={`/chats/${username}`} 
+              className="Sidebar-link__reset"
+              key={nanoid()} 
+              onClick={onChatClick.bind(this, username)}
+            >
+              <ListItem 
+                button 
+                divider
+                selected={activeChat === username}
+              >
+                <ListItemAvatar>
+                  <Badge color="secondary" variant="dot" invisible={!fired}>
+                    <Avatar className={palette[idx % 8]}>
+                      {username.slice(0, 1).toUpperCase()}
+                    </Avatar>
+                  </Badge>
+                </ListItemAvatar>
+                <ListItemText 
+                  classes={{ secondary: 'Sidebar-last__message' }} 
+                  primary={username} 
+                  secondary={lastMessage.username === user ? `You: ${lastMessageText}` : `${lastMessageText}`}
+                />
               </ListItem>
             </Link>
           );

--- a/AlexanderMandrov/React/Messenger/src/constants/constants.js
+++ b/AlexanderMandrov/React/Messenger/src/constants/constants.js
@@ -120,33 +120,28 @@ const rawMessages = [
   'I appreciate all of your opinions.',
 ];
 
-const paletteLength = 8;
-
-let notifications = [],
-  avatarColors = [],
-  messages = [];
+let messages = [];
 
 usernames.forEach(() => {
-  notifications.push(Math.floor(Math.random() * 20));
-  avatarColors.push(Math.floor(Math.random() * paletteLength));
   messages.push(rawMessages[Math.floor(Math.random() * 5)]);
 });
 
 const createPrimaryChats = (usernames, sender = null) => {
   return usernames.map((user, id) => {
     return {
-      id: id,
+      id: nanoid(),
+      fired: true,
       username: user,
-      messages: [
+      messages: sender ? [] : [
         {
           id: nanoid(),
           username: sender ? sender : user,
           date: (new Date()),
-          text: sender ? 'Hi there!' : messages[id]
+          text: messages[id]
         }
       ]
     }
   });
 };
 
-export { usernames, notifications, avatarColors, createPrimaryChats, rawProfileInfo, stickers };
+export { usernames, createPrimaryChats, rawProfileInfo, stickers };

--- a/AlexanderMandrov/React/Messenger/src/index.js
+++ b/AlexanderMandrov/React/Messenger/src/index.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import store from './redux/store';
+import { ConnectedRouter } from  'connected-react-router';
+import { PersistGate } from 'redux-persist/integration/react';
+import { history, initStore } from './redux/store';
 import App from './components/App';
+
+const { store, persistor } = initStore();
 
 ReactDOM.render(
   <Provider store={store}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <PersistGate persistor={persistor}>
+      <ConnectedRouter history={history}>
+        <App />
+      </ConnectedRouter>
+    </PersistGate>
   </Provider>,
   document.getElementById('root')
 );

--- a/AlexanderMandrov/React/Messenger/src/redux/ducks/chats.js
+++ b/AlexanderMandrov/React/Messenger/src/redux/ducks/chats.js
@@ -5,7 +5,9 @@ import { createMessage, createBotMessage } from '../../utils/utils';
 const SET_CHATS = 'chats/SET_CHATS',
   SET_SEND_MESSAGE = 'chats/SET_SEND_MESSAGE',
   SET_SEND_BOT_MESSAGE = 'chats/SET_SEND_BOT_MESSAGE',
-  SET_NEW_CHAT = 'chats/SET_NEW_CHAT';
+  SET_NEW_CHAT = 'chats/SET_NEW_CHAT',
+  SET_FIRE_CHAT = 'chats/SET_FIRE_CHAT',
+  SET_RECEIVER = 'chats/SET_RECEIVER';
 
 const initialState = {
   chats: null,
@@ -17,12 +19,13 @@ const setChats = (chats) => ({
   chats
 });
 
-const setSendMessage = (messageText, sender, chatId) => ({
+const setSendMessage = (messageText, sender, chatId, receiver) => ({
   type: SET_SEND_MESSAGE,
   payload: {
     text: messageText,
     username: sender,
-    chatId
+    chatId,
+    receiver
   }
 });
 
@@ -38,6 +41,19 @@ const setSendBotMessage = (sender, receiver, chatId) => ({
 const setNewChat = (chat) => ({
   type: SET_NEW_CHAT,
   chat
+});
+
+const setFireChat = (fire, chatId) => ({
+  type: SET_FIRE_CHAT,
+  payload: {
+    fired: fire,
+    chatId
+  }
+});
+
+const setReceiver = (receiver) => ({
+  type: SET_RECEIVER,
+  receiver
 });
 
 const fetchChats = (usernames) => {
@@ -81,10 +97,23 @@ const chatsReducer = (state = initialState, action) => {
         ...state,
         chats: [action.chat, ...state.chats]
       }
+    case SET_FIRE_CHAT:
+      return {
+        ...state,
+        chats: state.chats.map((chat, idx) => {
+          if (idx === action.payload.chatId) chat.fired = action.payload.fired;
+          return chat
+        })
+      }
+    case SET_RECEIVER:
+      return {
+        ...state,
+        receiver: action.receiver
+      }
     default:
       return state;    
   }
 };
 
 export default chatsReducer;
-export { fetchChats, setSendMessage, setNewChat, setChats, setSendBotMessage };
+export { fetchChats, setSendMessage, setNewChat, setChats, setSendBotMessage, SET_SEND_MESSAGE, SET_SEND_BOT_MESSAGE, setFireChat, setReceiver };

--- a/AlexanderMandrov/React/Messenger/src/redux/middlewares/fire.js
+++ b/AlexanderMandrov/React/Messenger/src/redux/middlewares/fire.js
@@ -1,0 +1,16 @@
+import { findChatIndexByReceiver, findChatByReceiver } from '../../utils/utils';
+import { setFireChat } from '../ducks/chats';
+
+export const fireMiddleware = store => next => action => {
+  if (action.type === '@@router/LOCATION_CHANGE') {
+    const receiver = action.payload.location.pathname.split('/')[2];
+    const { chatsReducer } = store.getState();
+    const { chats } = chatsReducer;
+    if (chats && receiver) {
+      const chat = findChatByReceiver(chats, receiver);
+      if (chat.fired) store.dispatch(setFireChat(!chat.fired, findChatIndexByReceiver(chats, receiver)));
+    }
+  }
+  
+  return next(action);
+};

--- a/AlexanderMandrov/React/Messenger/src/redux/middlewares/message.js
+++ b/AlexanderMandrov/React/Messenger/src/redux/middlewares/message.js
@@ -1,0 +1,28 @@
+import { SET_SEND_MESSAGE, SET_SEND_BOT_MESSAGE, setSendBotMessage, setFireChat } from '../ducks/chats';
+
+let timeout = null;
+
+export const messageMiddleware = store => next => action => {
+  if (action.type === SET_SEND_MESSAGE) {
+    const { username, receiver, chatId } = action.payload;
+
+    if (username !== 'Bot') {
+      timeout = setTimeout(() => {
+        store.dispatch(setSendBotMessage(username, receiver, chatId));
+      }, 2000);
+    }
+  }
+
+  if (action.type === SET_SEND_BOT_MESSAGE) {
+    const { receiver, chatId } = action.payload;
+    const { router } = store.getState();
+
+    clearTimeout(timeout);
+
+    if (router.location.pathname !== `/chats/${receiver}`) {
+      store.dispatch(setFireChat(true, chatId));
+    }
+  }
+
+  return next(action);
+};

--- a/AlexanderMandrov/React/Messenger/src/redux/rootReducer.js
+++ b/AlexanderMandrov/React/Messenger/src/redux/rootReducer.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
+import { connectRouter } from 'connected-react-router';
 import chatsReducer from './ducks/chats';
 import profileReducer from './ducks/profile';
 
-const rootReducer = combineReducers({
+const createRootReducer = (history) => combineReducers({
+  router: connectRouter(history),
   chatsReducer,
   profileReducer
 });
 
-export default rootReducer;
+export default createRootReducer;

--- a/AlexanderMandrov/React/Messenger/src/redux/store.js
+++ b/AlexanderMandrov/React/Messenger/src/redux/store.js
@@ -1,10 +1,39 @@
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
+import { createBrowserHistory } from 'history';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 import thunk from 'redux-thunk';
-import rootReducer from './rootReducer';
+import logger from 'redux-logger';
+import { routerMiddleware } from 'connected-react-router';
+import { fireMiddleware } from './middlewares/fire';
+import { messageMiddleware } from './middlewares/message';
+import createRootReducer from './rootReducer';
 
-const store = createStore(rootReducer, composeWithDevTools(
-    applyMiddleware(thunk)
-));
+export const history = createBrowserHistory();
 
-export default store;
+const persistConfig = {
+  key: 'root',
+  storage,
+};
+
+const middlewares = [
+  thunk,
+  logger,
+  fireMiddleware,
+  messageMiddleware,
+  routerMiddleware(history)
+];
+
+export const initStore = () => {
+  const initialStore = {};
+
+  const store = createStore(
+    persistReducer(persistConfig, createRootReducer(history)),
+    initialStore,
+    composeWithDevTools(applyMiddleware(...middlewares))
+  );
+
+  const persistor = persistStore(store);
+  return { store, persistor };
+};

--- a/AlexanderMandrov/React/Messenger/src/utils/utils.js
+++ b/AlexanderMandrov/React/Messenger/src/utils/utils.js
@@ -39,12 +39,6 @@ const findChatIndexByReceiver = (chats, receiver) => {
   return index;
 };
 
-const setDelay = (sender, receiver, dispatch, setSendBotMessage, editIdx = 0) => {
-  setTimeout(() => {
-    dispatch(setSendBotMessage(sender, receiver, editIdx));
-  }, 2000);
-};
-
 const createProfileInfo = (profileInfo) => {
   return {
     ...profileInfo,
@@ -53,4 +47,5 @@ const createProfileInfo = (profileInfo) => {
   };
 };
 
-export { createMessage, createBotMessage, validateInput, messageShorter, findChatByReceiver, findChatIndexByReceiver, setDelay, createProfileInfo };
+export { createMessage, createBotMessage, validateInput, messageShorter, 
+  findChatByReceiver, findChatIndexByReceiver, createProfileInfo };


### PR DESCRIPTION
Подключил redux-logger, redux-persist.
Логику ответа бота перенес в messageMiddleware.
Мигание сделал с помощью fireMiddleware (индикацию непрочитанных сообщений в каком-либо чате. Для того, чтобы увидеть эту индикацию, нужно написать сообщение и перейти на другой чат.).
Link на рутовую страницу в хедере заменил на push из connected-react-router (кликать на "Messenger" в шапке).
Исправил баг с палеткой, когда при создании нового чата, самый последний терял цвет иконки.
Сделал программный переход при создании нового чата в него, теперь новые чаты пустые. 
Исправил баг с отображением времени, так как после записи в localStorage date obj превращался в строку. 
P.S. Возможность удаления своих сообщений присутствовала в прошлых версиях.